### PR TITLE
Portfolio: preserve data in the browser

### DIFF
--- a/index.html
+++ b/index.html
@@ -808,13 +808,13 @@
         <form class="contact_last_session" action="https://formspree.io/f/xqkngjdg" method="POST">
           <ul class="form_contact">
             <li>
-              <label for="text1"></label>
-              <input type="text" id="text1" name="user_name" maxlength="30" placeholder="Yeremias"
-                pattern="[a-z]{1,30}" />
+              <label for="name"></label>
+              <input id="name" type="text" name="user_name" maxlength="30" placeholder="Yeremias"
+                />
             </li>
             <li>
-              <label for="text1"></label>
-              <input type="email" class="text1" size="32" name="contact_email" maxlength="32"
+              <label for="email"></label>
+              <input id="email" type="email" size="32" name="contact_email" maxlength="32"
                 placeholder="natajayanj14@gmail.com" title="Please Enter Valide Email Id" />
             </li>
             <li>
@@ -830,6 +830,7 @@
   </main>
   <script src="index.js"></script>
   <script src="data.js"></script>
+  <script src="preserve-data.js"></script>
 </body>
 
 </html>

--- a/preserve-data.js
+++ b/preserve-data.js
@@ -1,0 +1,28 @@
+const inputName = document.getElementById('name');
+const inputEmail = document.getElementById('email');
+const inputMessage = document.getElementById('msg');
+const values = [inputName, inputEmail, inputMessage];
+function returnAllData() {
+  const obj = {};
+  for (let i = 0; i < values.length; i += 1) {
+    obj[values[i].id] = values[i].value;
+  }
+  return obj;
+}
+function setForm() {
+  const formData = JSON.parse(localStorage.getItem('form_data'));
+  inputName.value = formData.name;
+  inputEmail.value = formData.email;
+  inputMessage.value = formData.msg;
+}
+function setStorage() {
+  localStorage.setItem('form_data', JSON.stringify(returnAllData()));
+}
+if (!localStorage.getItem('form_data')) {
+  setStorage();
+} else {
+  setForm();
+}
+inputName.setAttribute('onchange', 'setStorage()');
+inputEmail.setAttribute('onchange', 'setStorage()');
+inputMessage.setAttribute('onchange', 'setStorage()');


### PR DESCRIPTION
On this pull request, I'll use local storage to save the form data in the local storage of the browser. That way when the user reloads the page the data they filled out in the form will be preserved. In order to do that, I created a single JavaScript object with all the data from the entire form and save it in local storage.

The first previous review is on this pull request: https://github.com/tingamapuro04/Portfolio/pull/15 due to linters problems we decided to do it in another pull request,